### PR TITLE
9주차 미션 / 서버 1조 김상준

### DIFF
--- a/src/main/java/kuit3/backend/common/argument_resolver/JwtAuthHandlerArgumentResolver.java
+++ b/src/main/java/kuit3/backend/common/argument_resolver/JwtAuthHandlerArgumentResolver.java
@@ -1,6 +1,9 @@
 package kuit3.backend.common.argument_resolver;
 
 import jakarta.servlet.http.HttpServletRequest;
+import kuit3.backend.jwt.JwtUtil;
+import kuit3.backend.service.AuthService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -12,10 +15,13 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthHandlerArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtUtil jwtTokenUtil;
+    private final AuthService authService;
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasAnnotation = parameter.hasParameterAnnotation(PreAuthorize.class);
+        boolean hasAnnotation = parameter.hasParameterAnnotation(JwtAuthrize.class);
         boolean hasType = long.class.isAssignableFrom(parameter.getParameterType());
         log.info("hasAnnotation={}, hasType={}, hasAnnotation && hasType={}", hasAnnotation, hasType, hasAnnotation&&hasType);
         return hasAnnotation && hasType;
@@ -25,6 +31,16 @@ public class JwtAuthHandlerArgumentResolver implements HandlerMethodArgumentReso
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         log.info("userId={}", request.getAttribute("userId"));
-        return request.getAttribute("userId");
+
+        String accessToken = jwtTokenUtil.resolveAccessToken(request);
+        jwtTokenUtil.validateAccessToken(accessToken);
+        String email = jwtTokenUtil.getEmail(accessToken);
+        jwtTokenUtil.validatePayload(email);
+        long userId = authService.getUserIdByEmail(email);
+
+        // HttpServletRequest에 userId 속성 설정
+        //HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        request.setAttribute("userId", userId);
+        return userId;
     }
 }

--- a/src/main/java/kuit3/backend/common/argument_resolver/JwtAuthrize.java
+++ b/src/main/java/kuit3/backend/common/argument_resolver/JwtAuthrize.java
@@ -1,0 +1,11 @@
+package kuit3.backend.common.argument_resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtAuthrize {
+}

--- a/src/main/java/kuit3/backend/common/exception/ShopException.java
+++ b/src/main/java/kuit3/backend/common/exception/ShopException.java
@@ -1,0 +1,22 @@
+package kuit3.backend.common.exception;
+
+
+import kuit3.backend.common.response.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class ShopException extends RuntimeException {
+
+    private final ResponseStatus exceptionStatus;
+
+    public ShopException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public ShopException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+
+}

--- a/src/main/java/kuit3/backend/common/interceptor/JwtAuthInterceptor.java
+++ b/src/main/java/kuit3/backend/common/interceptor/JwtAuthInterceptor.java
@@ -7,6 +7,7 @@ import kuit3.backend.common.exception.jwt.unauthorized.JwtInvalidTokenException;
 import kuit3.backend.common.exception.jwt.bad_request.JwtNoTokenException;
 import kuit3.backend.common.exception.jwt.bad_request.JwtUnsupportedTokenException;
 import kuit3.backend.jwt.JwtProvider;
+import kuit3.backend.jwt.JwtUtil;
 import kuit3.backend.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,47 +25,48 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
     private static final String JWT_TOKEN_PREFIX = "Bearer ";
 
     private final JwtProvider jwtProvider;
+    private final JwtUtil jwtUtil;
     private final AuthService authService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 
-        String accessToken = resolveAccessToken(request);
-        validateAccessToken(accessToken);
+        String accessToken = jwtUtil.resolveAccessToken(request);
+        jwtUtil.validateAccessToken(accessToken);
 
         String email = jwtProvider.getPrincipal(accessToken);
-        validatePayload(email);
+        jwtUtil.validatePayload(email);
 
         long userId = authService.getUserIdByEmail(email);
         request.setAttribute("userId", userId);
         return true;
     }
 
-    private String resolveAccessToken(HttpServletRequest request) {
-        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        validateToken(token);
-        return token.substring(JWT_TOKEN_PREFIX.length());
-    }
-
-    private void validateToken(String token) {
-        if (token == null) {
-            throw new JwtNoTokenException(TOKEN_NOT_FOUND);
-        }
-        if (!token.startsWith(JWT_TOKEN_PREFIX)) {
-            throw new JwtUnsupportedTokenException(UNSUPPORTED_TOKEN_TYPE);
-        }
-    }
-
-    private void validateAccessToken(String accessToken) {
-        if (jwtProvider.isExpiredToken(accessToken)) {
-            throw new JwtExpiredTokenException(EXPIRED_TOKEN);
-        }
-    }
-
-    private void validatePayload(String email) {
-        if (email == null) {
-            throw new JwtInvalidTokenException(INVALID_TOKEN);
-        }
-    }
+//    private String resolveAccessToken(HttpServletRequest request) {
+//        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+//        validateToken(token);
+//        return token.substring(JWT_TOKEN_PREFIX.length());
+//    }
+//
+//    private void validateToken(String token) {
+//        if (token == null) {
+//            throw new JwtNoTokenException(TOKEN_NOT_FOUND);
+//        }
+//        if (!token.startsWith(JWT_TOKEN_PREFIX)) {
+//            throw new JwtUnsupportedTokenException(UNSUPPORTED_TOKEN_TYPE);
+//        }
+//    }
+//
+//    private void validateAccessToken(String accessToken) {
+//        if (jwtProvider.isExpiredToken(accessToken)) {
+//            throw new JwtExpiredTokenException(EXPIRED_TOKEN);
+//        }
+//    }
+//
+//    private void validatePayload(String email) {
+//        if (email == null) {
+//            throw new JwtInvalidTokenException(INVALID_TOKEN);
+//        }
+//    }
 
 }

--- a/src/main/java/kuit3/backend/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/kuit3/backend/common/response/status/BaseExceptionResponseStatus.java
@@ -45,8 +45,15 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     USER_NOT_FOUND(4003, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 회원입니다."),
     PASSWORD_NO_MATCH(4004, HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
     INVALID_USER_STATUS(4005, HttpStatus.BAD_REQUEST.value(), "잘못된 회원 status 값입니다."),
-    EMAIL_NOT_FOUND(4006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다.");
-
+    EMAIL_NOT_FOUND(4006, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 이메일입니다."),
+    DUPLICATE_SHOP_NAME(4007,HttpStatus.BAD_REQUEST.value(),"이미 존재하는 가게 이름 입니다."),
+    FOODCATEGORY_NOT_MATCH(4008,HttpStatus.BAD_REQUEST.value(),"없는 카테고리 입니다."),
+    //WISH_LIST_INVALID(4009,HttpStatus.BAD_REQUEST.value(),"찜 목록 "),
+    INVALID_SHOP_VALUE(5000, HttpStatus.BAD_REQUEST.value(), "가게 등록 요청에서 잘못된 값이 존재합니다."),
+    INVALID_USER_ID(4009, HttpStatus.BAD_REQUEST.value(), "유효하지 않은 사용자 Id입니다"),
+    INVALID_SHOP_ID(4010, HttpStatus.BAD_REQUEST.value(), "유효하지 않는 가게 Id입니다."),
+    DUPLICATED_USER_ADDRESS(4011, HttpStatus.BAD_REQUEST.value(), "이미 존재하는 주소 입니다"),
+    INVALID_ADDRESS_INPUT(4010, HttpStatus.BAD_REQUEST.value(), "유효하지 않는 가게 Id입니다."),;
     private final int code;
     private final int status;
     private final String message;

--- a/src/main/java/kuit3/backend/config/WebConfig.java
+++ b/src/main/java/kuit3/backend/config/WebConfig.java
@@ -21,7 +21,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAuthenticationInterceptor)
                 .order(1)
-                .addPathPatterns("/auth/test");
+                //.addPathPatterns("/auth/test")
+                .addPathPatterns("/auth/user-info")
+                .addPathPatterns("/users/**")
+                .excludePathPatterns("/users");
     }
 
     @Override

--- a/src/main/java/kuit3/backend/controller/AuthController.java
+++ b/src/main/java/kuit3/backend/controller/AuthController.java
@@ -1,5 +1,6 @@
 package kuit3.backend.controller;
 
+import kuit3.backend.common.argument_resolver.JwtAuthrize;
 import kuit3.backend.common.argument_resolver.PreAuthorize;
 import kuit3.backend.common.exception.UserException;
 import kuit3.backend.common.response.BaseResponse;
@@ -39,6 +40,18 @@ public class AuthController {
      */
     @GetMapping("/test")
     public BaseResponse<String> checkAuthorization(@PreAuthorize Long userId) {
+        return new BaseResponse<>("userId=" + userId);
+    }
+    @GetMapping("/test-jwt")
+    public BaseResponse<String> checkJwtAuthorization(@JwtAuthrize long userId) {
+        return new BaseResponse<>("userId=" + userId);
+    }
+    @GetMapping("/user-info")
+    public BaseResponse<String> getUserInfo(@RequestAttribute("userId") Long userId) {
+        // userId를 이용하여 비즈니스 로직 수행
+        // 예: 사용자 정보를 데이터베이스에서 조회
+        //authService.findUserById(userId);
+
         return new BaseResponse<>("userId=" + userId);
     }
 

--- a/src/main/java/kuit3/backend/controller/ShopController.java
+++ b/src/main/java/kuit3/backend/controller/ShopController.java
@@ -1,0 +1,77 @@
+package kuit3.backend.controller;
+
+
+import com.fasterxml.jackson.databind.annotation.JsonValueInstantiator;
+import kuit3.backend.common.exception.ShopException;
+import kuit3.backend.common.response.BaseResponse;
+import kuit3.backend.dto.shop.*;
+import kuit3.backend.service.ShopService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.INVALID_SHOP_VALUE;
+import static kuit3.backend.util.BindingResultUtils.getErrorMessages;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shop")
+public class ShopController {
+    private final ShopService shopService;
+
+    /**
+    * shop 추가
+     * */
+    @PostMapping("")
+    public BaseResponse<PostShopResponse> signUp(@Validated @RequestBody PostShopRequest postShopRequest, BindingResult bindingResult) {
+        log.info("[ShopController.addShop]");
+        if (bindingResult.hasErrors()) {
+            throw new ShopException(INVALID_SHOP_VALUE, getErrorMessages(bindingResult));
+        }
+        return new BaseResponse<>(shopService.addShop(postShopRequest));
+    }
+    @GetMapping("/list")
+    public BaseResponse<List<Shop>> getShops(@RequestParam(required = false) String category, @RequestParam(required = false) String address) {
+        if (category != null && address != null) {
+            // 카테고리와 주소로 가게 검색
+            return new BaseResponse<>(shopService.getShopsByCategoryAndAddress(category, address));
+
+        } else if (category != null) {
+            // 카테고리로 가게 검색
+            return new BaseResponse<>(shopService.getShopsByCategory(category));
+        } else if (address != null) {
+            // 주소로 가게 검색
+            return new BaseResponse<>(shopService.getShopsByAddress(address));
+        } else {
+            // 카테고리와 주소가 주어지지 않은 경우 모든 가게 목록 반환
+            return new BaseResponse<>( shopService.getAllShops());
+        }
+    }
+    @GetMapping("/list-page")
+    public BaseResponse<GetShopListResponse> getShopPage(@Validated @RequestBody GetShopListRequest getShopListRequest) {
+        return new BaseResponse<>(shopService.getShopList(getShopListRequest));
+    }
+    @GetMapping("/detail")
+    public BaseResponse<List<Shop>> getShopDetail(@Validated @RequestParam long shopId, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new ShopException(INVALID_SHOP_VALUE, getErrorMessages(bindingResult));
+        }
+        return new BaseResponse<>(shopService.getShopById(shopId));
+    }
+
+    @GetMapping("/food-categories")
+    public List<FoodCategory> getAllFoodCategories() {
+        return shopService.getAllFoodCategories();
+    }
+
+    @PostMapping("/food-categories/{foodCategory}")
+    public BaseResponse<String> postAllFoodCategories(@Range(min=1,max=10) @PathVariable String foodCategory) {
+        return new BaseResponse<>(shopService.addFoodCategory(foodCategory));
+    }
+}

--- a/src/main/java/kuit3/backend/controller/WishlistController.java
+++ b/src/main/java/kuit3/backend/controller/WishlistController.java
@@ -1,0 +1,36 @@
+package kuit3.backend.controller;
+
+
+import kuit3.backend.common.response.BaseResponse;
+import kuit3.backend.dto.wishlist.GetWishlistRequest;
+import kuit3.backend.dto.wishlist.PostWishlistRequest;
+import kuit3.backend.dto.wishlist.PostWishlistResponse;
+import kuit3.backend.service.WishlistService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static kuit3.backend.util.BindingResultUtils.getErrorMessages;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/wishlist")
+public class WishlistController {
+    private final WishlistService wishlistService;
+    @PostMapping("")
+    public BaseResponse<PostWishlistResponse> getWishlist(@Validated @RequestBody PostWishlistRequest wishLisRreq, BindingResult bindingResult){
+        if (bindingResult.hasErrors()) {
+            throw new RuntimeException( getErrorMessages(bindingResult));
+        }
+        return new BaseResponse<>(wishlistService.createWishlist(wishLisRreq));
+    }
+    @GetMapping("")
+    public BaseResponse<Object> getWishlist(@Validated @RequestBody GetWishlistRequest wishLisRreq, BindingResult bindingResult){
+
+        return new BaseResponse<>(wishlistService.getWishlist(wishLisRreq));
+    }
+}

--- a/src/main/java/kuit3/backend/dao/ShopDao.java
+++ b/src/main/java/kuit3/backend/dao/ShopDao.java
@@ -1,0 +1,169 @@
+package kuit3.backend.dao;
+
+
+import kuit3.backend.dto.shop.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Repository
+public class ShopDao {
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public ShopDao(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+    }
+
+    public long createShop(PostShopRequest shop) {
+        String sql = "INSERT INTO Shop (shop_name, shop_call_num, status, address, food_category) " +
+                "VALUES (:shopName, :shopCallNum, 'open', :address, :foodCategory)";
+
+//        Map<String, Object> paramMap = Map.of(
+//                "shopName", shop.getShopName(),
+//                "shopCallNum", shop.getPhoneNumber(),
+////                "isOpenNow", shop.isOpenNow(),
+//                "address", shop.getAddress(),
+//                "foodCategory", shop.getFoodCategory()
+//        );
+        SqlParameterSource param = new BeanPropertySqlParameterSource(shop);
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        namedParameterJdbcTemplate.update(sql, param, keyHolder);
+
+        return Objects.requireNonNull(keyHolder.getKey()).longValue();
+
+        //return namedParameterJdbcTemplate.update(sql, paramMap);
+    }
+    public void createFoodCategory(String foodCategory) {
+        String sql = "INSERT INTO `food_category` (`food_category`) " +
+                "VALUES (:foodCategory)";
+
+        SqlParameterSource param = new MapSqlParameterSource().addValue("foodCategory", foodCategory);
+        namedParameterJdbcTemplate.update(sql, param);
+
+        //return namedParameterJdbcTemplate.update(sql, paramMap);
+    }
+
+    public boolean hasDuplicateShopName(String shopName){
+        String sql = "select exists(select shop_name from shop where shop_name=:shopName)";
+        Map<String, Object> param = Map.of("shopName", shopName);
+        return Boolean.TRUE.equals(namedParameterJdbcTemplate.queryForObject(sql, param, boolean.class));
+    }
+
+
+
+    public List<Shop> getShopsByAddress(String address) {
+        String sql = "SELECT * FROM Shop WHERE address = :address";
+        Map<String, Object> paramMap = Collections.singletonMap("address", address);
+
+        return namedParameterJdbcTemplate.query(sql, paramMap, (rs, rowNum) -> {
+            Shop shop = new Shop();
+            shop.setShopId(rs.getLong("Shop_id"));
+            shop.setShopName(rs.getString("shop_name"));
+            shop.setShopCallNum(rs.getString("shop_call_num"));
+            shop.setOpenNow(rs.getBoolean("is_open_now"));
+            shop.setAddress(rs.getString("address"));
+            shop.setFoodCategory(rs.getString("food_category"));
+            return shop;
+        });
+    }
+
+    public List<Shop> getAllShops() {
+        String sql = "SELECT * FROM Shop";
+        return namedParameterJdbcTemplate.query(sql, (rs, rowNum) -> {
+            Shop shop = new Shop();
+            shop.setShopId(rs.getLong("Shop_id"));
+            shop.setShopName(rs.getString("shop_name"));
+            shop.setShopCallNum(rs.getString("shop_call_num"));
+            shop.setOpenNow(rs.getBoolean("is_open_now"));
+            shop.setAddress(rs.getString("address"));
+            shop.setFoodCategory(rs.getString("food_category"));
+            return shop;
+        });
+    }
+
+    public List<GetShopResponseEntity> findShopsByStartShopId(GetShopListRequest getShopListRequest) {
+        String sql = "SELECT shop_name AS shopName, shop_call_num AS shopCallNumber, address,shop_id AS shopId " +
+                "FROM shop " +
+                "WHERE shop_id >= :startShopId and food_category= :foodCategory and address=:address " +
+                "LIMIT :limit";
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("startShopId", getShopListRequest.getLastId())
+                .addValue("foodCategory", getShopListRequest.getFoodCategory())
+                .addValue("address", getShopListRequest.getAddress())
+                .addValue("limit", getShopListRequest.getNumber());
+        return namedParameterJdbcTemplate.query(sql, params, new BeanPropertyRowMapper<>(GetShopResponseEntity.class));
+    }
+
+    public List<Shop> getShopById(long shopId) {
+        String sql = "SELECT * FROM Shop WHERE Shop_id = :shopId";
+        Map<String, Object> paramMap = Collections.singletonMap("shopId", shopId);
+
+        return namedParameterJdbcTemplate.query(sql, paramMap, (rs, rowNum) -> {
+            Shop shop = new Shop();
+            shop.setShopId(rs.getLong("Shop_id"));
+            shop.setShopName(rs.getString("shop_name"));
+            shop.setShopCallNum(rs.getString("shop_call_num"));
+            shop.setOpenNow(rs.getBoolean("is_open_now"));
+            shop.setAddress(rs.getString("address"));
+            shop.setFoodCategory(rs.getString("food_category"));
+            return shop;
+        });
+    }
+    public List<Shop> getShopsByCategory(String category) {
+        String sql = "SELECT * FROM Shop WHERE food_category = :category";
+        Map<String, Object> paramMap = Collections.singletonMap("category", category);
+
+        return namedParameterJdbcTemplate.query(sql, paramMap, (rs, rowNum) -> mapRowToShop(rs));
+    }
+    public boolean hasDuplicateFoodCategoryName(String foodCategory){
+        String sql = "select exists(select food_category from food_category WHERE food_category=:foodCategory)";
+        Map<String, Object> param = Map.of("foodCategory", foodCategory);
+        return Boolean.TRUE.equals(namedParameterJdbcTemplate.queryForObject(sql, param, boolean.class));
+    }
+
+    public List<Shop> getShopsByCategoryAndAddress(String category, String address) {
+        String sql = "SELECT * FROM Shop WHERE food_category = :category AND address = :address";
+        Map<String, Object> paramMap = Map.of("category", category, "address", address);
+
+        return namedParameterJdbcTemplate.query(sql, paramMap, (rs, rowNum) -> mapRowToShop(rs));
+    }
+    private Shop mapRowToShop(ResultSet rs) throws SQLException {
+        Shop shop = new Shop();
+        shop.setShopId(rs.getLong("Shop_id"));
+        shop.setShopName(rs.getString("shop_name"));
+        shop.setShopCallNum(rs.getString("shop_call_num"));
+        shop.setOpenNow(rs.getBoolean("is_open_now"));
+        shop.setAddress(rs.getString("address"));
+        shop.setFoodCategory(rs.getString("food_category"));
+        return shop;
+    }
+
+    public List<FoodCategory> getAllFoodCategories() {
+        String sql = "SELECT food_category FROM food_category";
+        return namedParameterJdbcTemplate.query(sql, (rs, rowNum) -> {
+            FoodCategory foodCategory = new FoodCategory();
+            foodCategory.setCategory(rs.getString("food_category"));
+            return foodCategory;
+        });
+    }
+    public boolean isExistId(long shopId) {
+        String sql = "select exists(select Shop_id from shop where Shop_id=:shopId)";
+        Map<String, Object> param = Map.of("shopId", shopId);
+        return Boolean.TRUE.equals(namedParameterJdbcTemplate.queryForObject(sql, param, boolean.class));
+    }
+
+}

--- a/src/main/java/kuit3/backend/dao/UserDao.java
+++ b/src/main/java/kuit3/backend/dao/UserDao.java
@@ -1,9 +1,13 @@
 package kuit3.backend.dao;
 
+import kuit3.backend.dto.shop.Shop;
 import kuit3.backend.dto.user.GetUserResponse;
 import kuit3.backend.dto.user.PostUserRequest;
+import kuit3.backend.dto.user.address.GetUserAddressResponse;
+import kuit3.backend.dto.user.address.PostUserAddressRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
@@ -11,6 +15,8 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +37,12 @@ public class UserDao {
         return Boolean.TRUE.equals(jdbcTemplate.queryForObject(sql, param, boolean.class));
     }
 
+    public boolean isExistId(long userId) {
+        String sql = "select exists(select User_id from user where User_id=:userId)"; //and status in ('active', 'dormant'))";
+        Map<String, Object> param = Map.of("userId", userId);
+        return Boolean.TRUE.equals(jdbcTemplate.queryForObject(sql, param, boolean.class));
+    }
+
     public boolean hasDuplicateNickName(String nickname) {
         String sql = "select exists(select email from user where nickname=:nickname and status in ('active', 'dormant'))";
         Map<String, Object> param = Map.of("nickname", nickname);
@@ -38,14 +50,38 @@ public class UserDao {
     }
 
     public long createUser(PostUserRequest postUserRequest) {
-        String sql = "insert into user(email, password, phone_number, nickname, profile_image) " +
-                "values(:email, :password, :phoneNumber, :nickname, :profileImage)";
+        String sql = "insert into user(email, password, phone_number, nickname, profile_image,status) " +
+                "values(:email, :password, :phoneNumber, :nickname, :profileImage, 'active')";
 
         SqlParameterSource param = new BeanPropertySqlParameterSource(postUserRequest);
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(sql, param, keyHolder);
 
         return Objects.requireNonNull(keyHolder.getKey()).longValue();
+    }
+
+    public int modifyUserStatus_dormant(long userId) {
+        String sql = "update user set status=:status where user_id=:user_id";
+        Map<String, Object> param = Map.of(
+                "status", "dormant",
+                "user_id", userId);
+        return jdbcTemplate.update(sql, param);
+    }
+
+    public int modifyUserStatus_deleted(long userId) {
+        String sql = "update user set status=:status where user_id=:user_id";
+        Map<String, Object> param = Map.of(
+                "status", "deleted",
+                "user_id", userId);
+        return jdbcTemplate.update(sql, param);
+    }
+
+    public int modifyNickname(long userId, String nickname) {
+        String sql = "update user set nickname=:nickname where user_id=:user_id";
+        Map<String, Object> param = Map.of(
+                "nickname", nickname,
+                "user_id", userId);
+        return jdbcTemplate.update(sql, param);
     }
 
     public List<GetUserResponse> getUsers(String nickname, String email, String status) {
@@ -79,27 +115,40 @@ public class UserDao {
         return jdbcTemplate.queryForObject(sql, param, String.class);
     }
 
-    public int modifyUserStatus_dormant(long userId) {
-        String sql = "update user set status=:status where user_id=:user_id";
-        Map<String, Object> param = Map.of(
-                "status", "dormant",
-                "user_id", userId);
-        return jdbcTemplate.update(sql, param);
+    public void createUserAddress(PostUserAddressRequest postUserAddressRequest) {
+        String sql = "insert into user_address(address_category,user_id,user_address) " +
+                "values(:addressCategory, :userId, :userAddress)";
+
+        SqlParameterSource param = new BeanPropertySqlParameterSource(postUserAddressRequest);
+        //KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(sql, param);
+
     }
 
-    public int modifyUserStatus_deleted(long userId) {
-        String sql = "update user set status=:status where user_id=:user_id";
-        Map<String, Object> param = Map.of(
-                "status", "deleted",
-                "user_id", userId);
-        return jdbcTemplate.update(sql, param);
-    }
 
-    public int modifyNickname(long userId, String nickname) {
-        String sql = "update user set nickname=:nickname where user_id=:user_id";
-        Map<String, Object> param = Map.of(
-                "nickname", nickname,
-                "user_id", userId);
-        return jdbcTemplate.update(sql, param);
+    public List<GetUserAddressResponse> getUserAddress(long userId) {
+        String sql = "SELECT * FROM user_address WHERE user_id = :userId ";
+        Map<String, Object> paramMap = Map.of("userId",userId);
+
+        return jdbcTemplate.query(sql, paramMap, (rs, rowNum) -> mapRowToShop(rs));
+    }
+    public boolean hasDuplicateUserAddress(PostUserAddressRequest postUserAddressRequest){
+        String sql = "SELECT COUNT(*) FROM User_address WHERE address_category = :addressCategory AND user_address = :userAddress";
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("addressCategory", postUserAddressRequest.getAddressCategory());
+        params.addValue("userAddress", postUserAddressRequest.getUserAddress());
+
+        int count = jdbcTemplate.queryForObject(sql, params, Integer.class);
+
+        return count > 0;
+    }
+    private GetUserAddressResponse mapRowToShop(ResultSet rs) throws SQLException {
+        Shop shop = new Shop();
+        GetUserAddressResponse userAddressResponse = new GetUserAddressResponse();
+        userAddressResponse.setUserAddress(rs.getString("user_address"));
+        userAddressResponse.setAddressCategory(rs.getString("address_category"));
+        return userAddressResponse;
     }
 }

--- a/src/main/java/kuit3/backend/dao/WishlistDao.java
+++ b/src/main/java/kuit3/backend/dao/WishlistDao.java
@@ -1,0 +1,68 @@
+package kuit3.backend.dao;
+
+
+import kuit3.backend.dto.wishlist.GetWishlistRequest;
+import kuit3.backend.dto.wishlist.GetWishlistResponse;
+import kuit3.backend.dto.wishlist.PostWishlistRequest;
+import kuit3.backend.dto.wishlist.PostWishlistResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+@Slf4j
+@Repository
+
+public class WishlistDao {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    public WishlistDao(DataSource dataSource) {
+        this.jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+    }
+
+    public PostWishlistResponse createWishlist(PostWishlistRequest postWishlistRequest) {
+        String sql = "insert into wish_list(User_id,Shop_id) " +
+                "values(:userId,:shopId)";
+
+        SqlParameterSource param = new BeanPropertySqlParameterSource(postWishlistRequest);
+        //KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(sql, param);
+
+        PostWishlistResponse postWishlistResponse = new PostWishlistResponse();
+        postWishlistResponse.setMessage("찜 목록에 추가 되었습니다.");
+        return postWishlistResponse;
+    }
+
+
+    public List<GetWishlistResponse> findShopsByUserId(GetWishlistRequest getWishlistRequest) {
+        String FIND_SHOPS_BY_USER_ID_SQL =
+                "SELECT s.Shop_id, s.shop_name " +
+                        "FROM wish_list w " +
+                        "JOIN Shop s ON w.Shop_id = s.Shop_id " +
+                        "WHERE w.User_id = :userId";
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("userId", getWishlistRequest.getUserId());
+
+        return jdbcTemplate.query(FIND_SHOPS_BY_USER_ID_SQL, params, new ShopRowMapper());
+    }
+
+    private static final class ShopRowMapper implements RowMapper<GetWishlistResponse> {
+        @Override
+        public GetWishlistResponse mapRow(ResultSet rs, int rowNum) throws SQLException {
+            GetWishlistResponse shop = new GetWishlistResponse();
+            shop.setShopId(rs.getLong("Shop_id"));
+            shop.setShopName(rs.getString("shop_name"));
+            return shop;
+        }
+
+    }
+}

--- a/src/main/java/kuit3/backend/dto/shop/FoodCategory.java
+++ b/src/main/java/kuit3/backend/dto/shop/FoodCategory.java
@@ -1,0 +1,14 @@
+package kuit3.backend.dto.shop;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class FoodCategory {
+    private String category;
+
+    // 생성자, getter 및 setter 메서드 생략
+}

--- a/src/main/java/kuit3/backend/dto/shop/GetShopListRequest.java
+++ b/src/main/java/kuit3/backend/dto/shop/GetShopListRequest.java
@@ -1,0 +1,31 @@
+package kuit3.backend.dto.shop;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.format.annotation.NumberFormat;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GetShopListRequest {
+    @NotBlank(message = "foodCategory: {NotBlank}")
+    @Length(max = 10, message = "foodCategory: 최대 {max}자리까지 가능합니다")
+    private String foodCategory;
+
+    @NotBlank(message = "address: {NotBlank}")
+    @Length(max = 50, message = "address: 최대 {max}자리까지 가능합니다")
+    private String address;
+
+    @NotNull
+    private long lastId;
+
+    @NotNull
+    @Min(value = 1, message = "Value must be greater than or equal to 1")
+    private int number = 10;
+}

--- a/src/main/java/kuit3/backend/dto/shop/GetShopListResponse.java
+++ b/src/main/java/kuit3/backend/dto/shop/GetShopListResponse.java
@@ -1,0 +1,15 @@
+package kuit3.backend.dto.shop;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GetShopListResponse {
+    private List<GetShopResponseEntity> shopList;
+    private boolean hasNextPage;
+}

--- a/src/main/java/kuit3/backend/dto/shop/GetShopResponseEntity.java
+++ b/src/main/java/kuit3/backend/dto/shop/GetShopResponseEntity.java
@@ -1,0 +1,15 @@
+package kuit3.backend.dto.shop;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GetShopResponseEntity {
+    private long shopId;
+    private String shopName;
+    private String shopCallNumber;
+    private String address;
+}

--- a/src/main/java/kuit3/backend/dto/shop/PostShopRequest.java
+++ b/src/main/java/kuit3/backend/dto/shop/PostShopRequest.java
@@ -1,0 +1,28 @@
+package kuit3.backend.dto.shop;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class PostShopRequest {
+    @NotBlank(message = "shopName: {NotBlank}")
+    @Length(min=2, max=20,message = "shopName: 최소 {min}자리 ~ 최대 {max}자리까지 가능합니다")
+    private String shopName;
+
+    @NotBlank(message = "shop PhoneNumber: {NotBlank}")
+    @Length(max = 20, message = "phoneNumber: 최대 {max}자리까지 가능합니다")
+    private String shopCallNum;
+
+    @NotBlank(message = "address: {NotBlank}")
+    @Length(max = 50, message = "address: 최대 {max}자리까지 가능합니다")
+    private String address;
+
+    @NotBlank(message = "foodCategory: {NotBlank}")
+    @Length(max = 10, message = "foodCategory: 최대 {max}자리까지 가능합니다")
+    private String foodCategory;
+}

--- a/src/main/java/kuit3/backend/dto/shop/PostShopResponse.java
+++ b/src/main/java/kuit3/backend/dto/shop/PostShopResponse.java
@@ -1,0 +1,10 @@
+package kuit3.backend.dto.shop;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostShopResponse {
+    private long shopId;
+}

--- a/src/main/java/kuit3/backend/dto/shop/Shop.java
+++ b/src/main/java/kuit3/backend/dto/shop/Shop.java
@@ -1,0 +1,21 @@
+package kuit3.backend.dto.shop;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class Shop {
+    private long shopId;
+    private String shopName;
+    private String shopCallNum;
+    private boolean isOpenNow;
+    private String address;
+    private String foodCategory;
+
+    // 생성자, getter 및 setter 메서드 생략
+
+
+}

--- a/src/main/java/kuit3/backend/dto/user/PostUserRequest.java
+++ b/src/main/java/kuit3/backend/dto/user/PostUserRequest.java
@@ -30,7 +30,7 @@ public class PostUserRequest {
     @Length(max = 20, message = "phoneNumber: 최대 {max}자리까지 가능합니다")
     private String phoneNumber;
 
-    @Nullable
+    @NotBlank
     @Length(max = 25, message = "nickname: 최대 {max}자리까지 가능합니다")
     private String nickname;
 

--- a/src/main/java/kuit3/backend/dto/user/address/GetUserAddressResponse.java
+++ b/src/main/java/kuit3/backend/dto/user/address/GetUserAddressResponse.java
@@ -1,0 +1,14 @@
+package kuit3.backend.dto.user.address;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GetUserAddressResponse {
+    private String addressCategory;
+    private String userAddress;
+
+}

--- a/src/main/java/kuit3/backend/dto/user/address/PostUserAddressRequest.java
+++ b/src/main/java/kuit3/backend/dto/user/address/PostUserAddressRequest.java
@@ -1,0 +1,26 @@
+package kuit3.backend.dto.user.address;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kuit3.backend.common.argument_resolver.JwtAuthrize;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class PostUserAddressRequest {
+    @Nullable
+    private long userId;
+
+    @NotBlank
+    @Length(max = 10)
+    private String userAddress;
+
+    @NotBlank
+    @Length(max=20)
+    private String addressCategory;
+}

--- a/src/main/java/kuit3/backend/dto/wishlist/GetWishlistRequest.java
+++ b/src/main/java/kuit3/backend/dto/wishlist/GetWishlistRequest.java
@@ -1,0 +1,14 @@
+package kuit3.backend.dto.wishlist;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GetWishlistRequest {
+    @NotNull
+    private long userId;
+}

--- a/src/main/java/kuit3/backend/dto/wishlist/GetWishlistResponse.java
+++ b/src/main/java/kuit3/backend/dto/wishlist/GetWishlistResponse.java
@@ -1,0 +1,14 @@
+package kuit3.backend.dto.wishlist;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class GetWishlistResponse {
+    private long shopId;
+    private String shopName;
+
+}

--- a/src/main/java/kuit3/backend/dto/wishlist/PostWishlistRequest.java
+++ b/src/main/java/kuit3/backend/dto/wishlist/PostWishlistRequest.java
@@ -1,0 +1,17 @@
+package kuit3.backend.dto.wishlist;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class PostWishlistRequest {
+    @NotNull
+    private long userId;
+    @NotNull
+    private long shopId;
+}

--- a/src/main/java/kuit3/backend/dto/wishlist/PostWishlistResponse.java
+++ b/src/main/java/kuit3/backend/dto/wishlist/PostWishlistResponse.java
@@ -1,0 +1,13 @@
+package kuit3.backend.dto.wishlist;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class PostWishlistResponse {
+    private String message;
+
+}

--- a/src/main/java/kuit3/backend/jwt/JwtProvider.java
+++ b/src/main/java/kuit3/backend/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package kuit3.backend.jwt;
 
 import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
 import kuit3.backend.common.exception.jwt.unauthorized.JwtInvalidTokenException;
 import kuit3.backend.common.exception.jwt.unauthorized.JwtMalformedTokenException;
 import kuit3.backend.common.exception.jwt.bad_request.JwtUnsupportedTokenException;
@@ -8,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
 import java.util.Date;
 
 import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.*;
@@ -15,13 +17,13 @@ import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.*
 @Slf4j
 @Component
 public class JwtProvider {
-
+    @Value("${secret.jwt-expired-in}")
+    private long JWT_EXPIRED_IN;
     @Value("${secret.jwt-secret-key}")
     private String JWT_SECRET_KEY;
 
-    @Value("${secret.jwt-expired-in}")
-    private long JWT_EXPIRED_IN;
 
+    //private static final Key JWT_SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS256);
     public String createToken(String principal, long userId) {
         log.info("JWT key={}", JWT_SECRET_KEY);
 

--- a/src/main/java/kuit3/backend/jwt/JwtUtil.java
+++ b/src/main/java/kuit3/backend/jwt/JwtUtil.java
@@ -1,0 +1,56 @@
+package kuit3.backend.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import kuit3.backend.common.exception.jwt.bad_request.JwtNoTokenException;
+import kuit3.backend.common.exception.jwt.bad_request.JwtUnsupportedTokenException;
+import kuit3.backend.common.exception.jwt.unauthorized.JwtExpiredTokenException;
+import kuit3.backend.common.exception.jwt.unauthorized.JwtInvalidTokenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.*;
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.INVALID_TOKEN;
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+    private static final String JWT_TOKEN_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    public String resolveAccessToken(HttpServletRequest request) {
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        validateToken(token);
+        return token.substring(JWT_TOKEN_PREFIX.length());
+    }
+//    public String resolveAccessToken(NativeWebRequest webRequest) {
+//        String token = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+//        validateToken(token);
+//        return token.substring(JWT_TOKEN_PREFIX.length());
+//    }
+
+    public void validateToken(String token) {
+        if (token == null) {
+            throw new JwtNoTokenException(TOKEN_NOT_FOUND);
+        }
+        if (!token.startsWith(JWT_TOKEN_PREFIX)) {
+            throw new JwtUnsupportedTokenException(UNSUPPORTED_TOKEN_TYPE);
+        }
+    }
+
+    public void validateAccessToken(String accessToken) {
+        if (jwtProvider.isExpiredToken(accessToken)) {
+            throw new JwtExpiredTokenException(EXPIRED_TOKEN);
+        }
+    }
+
+    public void validatePayload(String email) {
+        if (email == null) {
+            throw new JwtInvalidTokenException(INVALID_TOKEN);
+        }
+    }
+    public String getEmail(String accessToken) {
+        return jwtProvider.getPrincipal(accessToken);
+    }
+}

--- a/src/main/java/kuit3/backend/service/ShopService.java
+++ b/src/main/java/kuit3/backend/service/ShopService.java
@@ -1,0 +1,94 @@
+package kuit3.backend.service;
+
+
+import kuit3.backend.common.exception.ShopException;
+import kuit3.backend.dao.ShopDao;
+import kuit3.backend.dto.shop.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.DUPLICATE_SHOP_NAME;
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.FOODCATEGORY_NOT_MATCH;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShopService {
+    private final ShopDao shopDAO;
+
+
+    public List<Shop> getAllShops() {
+        return shopDAO.getAllShops();
+    }
+
+    public List<Shop> getShopById(long shopId) {
+        return shopDAO.getShopById(shopId);
+    }
+
+    public PostShopResponse addShop(PostShopRequest postShopRequest){
+        log.info("[ShopController : add Shop]");
+        validationShopName(postShopRequest.getShopName());
+
+        return new PostShopResponse(shopDAO.createShop(postShopRequest));
+    }
+    public List<Shop> getShopsByAddress(String address) {
+        return shopDAO.getShopsByAddress(address);
+    }
+    public List<Shop> getShopsByCategoryAndAddress(String category, String address) {
+        if(!shopDAO.hasDuplicateFoodCategoryName(category)){
+            throw new ShopException(FOODCATEGORY_NOT_MATCH);
+        }
+        return shopDAO.getShopsByCategoryAndAddress(category, address);
+    }
+    public List<Shop> getShopsByCategory(String category) {
+        if(!shopDAO.hasDuplicateFoodCategoryName(category)){
+            throw new ShopException(FOODCATEGORY_NOT_MATCH);
+        }
+        return shopDAO.getShopsByCategory(category);
+    }
+    public GetShopListResponse getShopList(GetShopListRequest getShopListRequest){
+        int howManyInPage = getShopListRequest.getNumber();
+        getShopListRequest.setLastId(getShopListRequest.getLastId()+1);
+        getShopListRequest.setNumber(howManyInPage+1);
+        GetShopListResponse getShopListResponse = new GetShopListResponse();
+        List<GetShopResponseEntity> result=shopDAO.findShopsByStartShopId(getShopListRequest);
+
+        int listSize = result.size();
+        if(listSize>howManyInPage){
+            getShopListResponse.setHasNextPage(true);
+            result.subList(howManyInPage, listSize).clear();
+        }else {
+            getShopListResponse.setHasNextPage(false);
+        }
+
+        getShopListResponse.setShopList(result);
+        return getShopListResponse;
+
+    }
+    public List<FoodCategory> getAllFoodCategories() {
+        return shopDAO.getAllFoodCategories();
+    }
+    public String addFoodCategory(String foodCategory){
+
+        if(shopDAO.hasDuplicateFoodCategoryName(foodCategory)){
+            return "이미 존재하는 카테고리 입니다.";
+        }
+        shopDAO.createFoodCategory(foodCategory);
+        return "새로운 카테고리 생성에 성공하였습니다";
+    }
+
+    private void validationShopName(String shopName){
+        if(shopDAO.hasDuplicateShopName(shopName)){
+            throw new ShopException(DUPLICATE_SHOP_NAME);
+        }
+    }
+    private void validationFoodCategory(String shopName){
+        if(shopDAO.hasDuplicateShopName(shopName)){
+            throw new ShopException(DUPLICATE_SHOP_NAME);
+        }
+    }
+
+}

--- a/src/main/java/kuit3/backend/service/WishlistService.java
+++ b/src/main/java/kuit3/backend/service/WishlistService.java
@@ -1,0 +1,54 @@
+package kuit3.backend.service;
+
+
+import kuit3.backend.common.exception.UserException;
+import kuit3.backend.common.response.status.ResponseStatus;
+import kuit3.backend.dao.ShopDao;
+import kuit3.backend.dao.UserDao;
+import kuit3.backend.dao.WishlistDao;
+import kuit3.backend.dto.wishlist.GetWishlistRequest;
+import kuit3.backend.dto.wishlist.GetWishlistResponse;
+import kuit3.backend.dto.wishlist.PostWishlistRequest;
+import kuit3.backend.dto.wishlist.PostWishlistResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.INVALID_SHOP_ID;
+import static kuit3.backend.common.response.status.BaseExceptionResponseStatus.INVALID_USER_ID;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WishlistService {
+
+    final private WishlistDao wishlistDao;
+    private final UserDao userDao;
+    private final ShopDao shopDao;
+    public void validationWishlistPost(PostWishlistRequest wishlistRequest){
+        if(!userDao.isExistId(wishlistRequest.getUserId())){
+            throw new UserException(INVALID_USER_ID);
+        }
+        if(!shopDao.isExistId(wishlistRequest.getShopId())){
+            throw new UserException(INVALID_SHOP_ID);
+        }
+    }
+
+    public PostWishlistResponse createWishlist(PostWishlistRequest wishlistRequest){
+        validationWishlistPost(wishlistRequest);
+        return wishlistDao.createWishlist(wishlistRequest);
+
+    }
+
+    public List<GetWishlistResponse> getWishlist(GetWishlistRequest wishlistRequest){
+        if(!userDao.isExistId(wishlistRequest.getUserId())){
+            throw new UserException(INVALID_USER_ID);
+        }
+        return wishlistDao.findShopsByUserId(wishlistRequest);
+
+    }
+    //public void deleteWishlist()
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,12 @@ spring:
     init:
       platform: mysql
 
+logging:
+  level:
+    org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate: DEBUG
+    org.springframework.jdbc.core.JdbcTemplate: DEBUG
+    org.springframework.jdbc.datasource.DataSourceTransactionManager: DEBUG
+    org.springframework.transaction.interceptor.TransactionInterceptor: DEBUG
 ---
 
 spring:
@@ -96,9 +102,6 @@ spring:
   config:
     activate:
       on-profile: "web-mvc"
-
-  mvc:
-    throw-exception-if-no-handler-found: true
 
   web:
     resources:

--- a/src/main/resources/application_backup.yml
+++ b/src/main/resources/application_backup.yml
@@ -1,6 +1,5 @@
 spring:
   profiles:
-    active: local
     group:
       "local": "localDB, devPort, secret, web-mvc"
       "dev": "devDB, devPort, secret, web-mvc"
@@ -14,9 +13,9 @@ spring:
       on-profile: "localDB"
 
   datasource:
-    url: application.yml
-    username: kuit
-    password:
+    url: ${DATASOURCE_URL_LOCAL}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     dbcp2:
       validation-query: select 1
@@ -94,8 +93,8 @@ spring:
       on-profile: "secret"
 
 secret:
-  jwt-secret-key: q8ZlTY3McB2+H1g7Tb2Y/h5jNTpVZ5u/bglWb0Otbh4=
-  jwt-expired-in: 36000000
+  jwt-secret-key: ${JWT_SECRET_KEY}
+  jwt-expired-in: ${JWT_EXPIRED_IN}
 
 ---
 


### PR DESCRIPTION
## 진행도 
 /users 하위 API 대상으로 **인증/인가** resolver 방식과 interceptor 방식으로 구현해서 API에 적용했습니다.
에 적용했습니다.
/shop/list-page 에 조건을 받으면  non-offset 방식으로 **paging** 구현하였습니다.

## userId
7,8주차까지의 API 설계에서는 인증/인가 기능이 없었기 때문에 user id를 pathvariable이나 request body에서 직접 받게 끔 구현하였습니다.
이번 주 미션부터는 token(혹은 session)에 사용자 id 혹은 정보가 직접 전달 되게 됩니다.  기존 API를 유지하면서 추가적으로 parameter에 user id와 authorize 된 user id가 같은지 비교하는 controller를 구현해보긴 하였으나, 불필요하다고 생각하여, Dto와 API를 수정하였습니다.

## paging
paging을 non offset(cursor) 방식으로 구현했습니다.
이때, 사용자가 전달하는 lastId를 +1 하는 코드와, 다음 page가 존재하는지 판단하여. hasNextPage 값을 response에 담아야 했습니다.
이런 값들을 조작하고, 읽어온 값을 판단해서 Dto에 담아주는 코드 부분들이 어느 레이어(Dao, service, controller)에 있어야 할지 고민하다가, data layer에는 최대한 단순히 입력값을 SQL로 치환하고, 결과 값을 객체로 변환하는 역할을 맡는 것이 좋고, controller에는 유효성 검사, service 호출을 하고 어떤 비즈니스 로직이 들어가면 좋지 않다고 생각해서 service에 해당 코드들을 작성했습니다.

## Anotation
argument resolver를 구현하는 과정에서 annotation을 직접 만들어 보고, 어떻게 argument resolver들이 작동하는지 알 수 있었습니다.
인가 처리와 같이 반복되는 코드들을 어노테이션으로 묶어 작성할 때 유용한 것 같습니다.
