### PR TITLE
9주차 미션 / 서버 1조 주민석

### DIFF
--- a/src/main/java/kuit3/backend/common/argument_resolver/JwtAuthHandlerArgumentResolver.java
+++ b/src/main/java/kuit3/backend/common/argument_resolver/JwtAuthHandlerArgumentResolver.java
@@ -3,7 +3,6 @@ package kuit3.backend.common.argument_resolver;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;


### PR DESCRIPTION
안녕하세요. 서버 1조 주민석입니다.
9주차 미션, 역시 7~8주차 미션을 수행했던 레포지토리에 이어서 작업했습니다.
아래 링크 확인해주시면 감사하겠습니다.! 😄

## 9주차 작업 수행 레포지토리 링크
https://github.com/emes-g/KUIT_My-REST-API/tree/release-1.2

## 미션 수행 내역
![image](https://github.com/Konkuk-KUIT/KUIT_3-Backend-Auth/assets/93303181/08c5dddb-6332-4468-bc8c-c85557ce64b5)
7, 8주차에 구현했던 API를 보완하였으며, 추가적으로 로그인 API를 설계하였습니다.

## 질문
제 생각대로라면, 무한 스크롤 구현 과정에서, 클라이언트가 스크롤을 내리면, 해당 화면을 유지한 채(위로 스크롤할 수 있는 상황에서) 밑에 새로운 데이터들이 추가되어야 합니다.
그런데, 제 구현 방식은 밑에 새로운 데이터들이 추가되긴 하지만, 화면이 최상단으로 올라가게 됩니다. (위로 스크롤할 수 없게)

제 구현 혹은 이해에서 잘못된 부분이 있다면 짚어주셨으면 좋겠습니다..!
또한, 다른 분들의 코드도 참고할 예정이지만 정답 코드도 한 번 보고 싶습니다!